### PR TITLE
refactor: Downsize amount of necessary space

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -209,28 +209,37 @@ process outputStats {
  */
 process combineUnmappedVCF {
     input:
-        path "variants1.vcf"
-        path "variants2.vcf"
+        path "variants1.vcf.gz"
+        path "variants2.vcf.gz"
 
     output:
-        path "merge.vcf", emit: merge_vcf
+        path "merge.vcf.gz", emit: merge_vcf
 
     """
-    cat variants1.vcf variants2.vcf > merge.vcf
+    set -euxo pipefail
+    if ![ -s variants1.vcf.gz && -s variants.vcf.gz ];
+        echo NULL > merged.vcf.gz
+    elif ![ -s variants1.vcf.gz ];
+        cp variants2.vcf.gz merged.vcf.gz
+    elif ![ -s variants2.vcf.gz ];
+        cp variants1.vcf.gz merged.vcf.gz
+    else
+        bcftools concat variants1.vcf.gz variants2.vcf.gz -Oz -o merge.vcf.gz
+    fi
     """
 }
 
 
 process combineVCF {
     input:
-        path "variants1.vcf"
-        path "variants2.vcf"
-        path "variants3.vcf"
+        path "variants1.vcf.gz"
+        path "variants2.vcf.gz"
+        path "variants3.vcf.gz"
     output:
-        path "merge.vcf", emit: merge_vcf
+        path "merge.vcf.gz", emit: merge_vcf
 
     """
-    cat variants1.vcf variants2.vcf variants3.vcf > merge.vcf
+    bcftools concat variants1.vcf.gz variants2.vcf.gz variants3.vcf.gz > merge.vcf.gz
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -216,15 +216,17 @@ process combineUnmappedVCF {
         path "merge.vcf.gz", emit: merge_vcf
 
     """
-    set -euxo pipefail
-    if ![ -s variants1.vcf.gz && -s variants.vcf.gz ];
-        echo NULL > merged.vcf.gz
-    elif ![ -s variants1.vcf.gz ];
-        cp variants2.vcf.gz merged.vcf.gz
-    elif ![ -s variants2.vcf.gz ];
-        cp variants1.vcf.gz merged.vcf.gz
-    else
+    if [ -s variants1.vcf.gz ] && [ -s variants2.vcf.gz ]
+    then
         bcftools concat variants1.vcf.gz variants2.vcf.gz -Oz -o merge.vcf.gz
+    elif [ -s variants1.vcf.gz ]
+    then
+        cp variants1.vcf.gz > merge.vcf.gz
+    elif [ -s variants2.vcf.gz ]
+    then
+        cp variants2.vcf.gz > merge.vcf.gz
+    else
+        echo NULL > merge.vcf.gz
     fi
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -49,7 +49,7 @@ outfile_dir = file(params.outfile).getParent()
 process filterInputVCF {
 
     input:
-        path "source.vcf"
+        path "source.vcf.gz"
         path "genome_fai"
 
     output:
@@ -61,9 +61,9 @@ process filterInputVCF {
     """
     awk '{ print \$1"\\t1\\t"\$2-1;}' genome_fai > center_regions.bed
     awk '{ print \$1"\\t0\\t1"; print \$1"\\t"\$2-1"\\t"\$2;}' genome_fai > edge_regions.bed
-    bcftools filter --targets-file center_regions.bed -Oz -o kept.vcf.gz source.vcf
+    bcftools filter --targets-file center_regions.bed -Oz -o kept.vcf.gz source.vcf.gz
     zcat kept.vcf.gz | grep -v '^#' | wc -l > all_count.txt
-    bcftools filter --targets-file edge_regions.bed -Oz -o filtered.vcf.gz source.vcf
+    bcftools filter --targets-file edge_regions.bed -Oz -o filtered.vcf.gz source.vcf.gz
     zcat filtered.vcf.gz | grep -v '^#' | wc -l > filtered_count.txt
     cat <(cat *_count.txt | awk '{sum += \$1} END{print "all: "sum}') <(cat filtered_count.txt | awk '{print "filtered: "\$1}') > count.yml
     """
@@ -76,13 +76,13 @@ process filterInputVCF {
 process storeVCFHeader {
 
     input:
-        path "source.vcf"
+        path "source.vcf.gz"
 
     output:
         path "vcf_header.txt", emit: vcf_header
 
     """
-    bcftools view --header-only source.vcf > vcf_header.txt
+    bcftools view --header-only source.vcf.gz > vcf_header.txt
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -162,7 +162,6 @@ process generateUnmappedVCF {
 
     output:
         path "${outfile_basename_without_ext}_unmapped.vcf.gz", emit: original_vcf_with_header
-        path "${outfile_basename_without_ext}_unmapped.vcf.gz.tbi", emit: original_vcf_with_header_idx
 
     """
     # Add header to the vcf file:

--- a/main.nf
+++ b/main.nf
@@ -169,7 +169,6 @@ process generateUnmappedVCF {
     cat original_header.txt > "${outfile_basename_without_ext}_unmapped.vcf"
     gunzip -c unmapped_variants.vcf.gz >> "${outfile_basename_without_ext}_unmapped.vcf"
     bgzip "${outfile_basename_without_ext}_unmapped.vcf"
-    tabix "${outfile_basename_without_ext}_unmapped.vcf.gz"
     """
 }
 

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -26,7 +26,7 @@ process convertVCFToBed {
     #  - add all VCF fields separated by 2 characters pipe and caret (|^) to avoid impacting existing formatting of
     #    the VCF line. The sub replacing percent is to protect the % character that would be interpreted by printf
     #    otherwise. the sub replacing space is to prevent bedtools from using them as a field separator
-    gzip source.vcf.gz | \
+    gunzip -c source.vcf.gz | \
     awk -F '\\t' '{ if (!/^#/){ \
                     printf $1"\\t"$2-1"\\t"$2"\\t"$1; \
                     for (i=2; i<=NF; i++){ gsub(/%/, "%%", $i); gsub(/ /, "£€", $i); printf "|^"$i }; print "\\t"$4}; \

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -133,7 +133,7 @@ process split_fasta {
         val chunk_size
 
     output:
-        path("read_chunk-*"), emit: read_split
+        path "read_chunk-*", emit: read_split
 
     script:
     if (interleaved_fasta.size() > 0)

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -7,18 +7,27 @@ nextflow.enable.dsl=2
 
 
 /*
- * Convert the VCF file to BED format storing the VCF line in the "name" column and the reference allele in the
- * "strand" column.
+ * Extract information about the original variants and put it in the fasta header
  */
-process convertVCFToBed {
+process extractVariantInfoToFastaHeader {
+
+    memory '6GB'
 
     input:
         path "source.vcf.gz"
+        path "genome.chrom.sizes"
+        path "genome.fa"
+        path "genome.fa.fai"
+        val flankingseq
 
     output:
-        path "variants.bed", emit: variants_bed
+        path "interleaved.fa", emit: interleaved_fasta
 
-    '''
+    script:
+    // The Flanking sequence will start/end one base up/downstream  of the variant.
+    // We need to add only (flankingseq - 1) to that base to have the correct flank length
+    flankingseq = flankingseq - 1
+    """
     # Convert the vcf file to bed format:
     #  - Remove all headers
     #  - Switch to 0 based coordinates system
@@ -28,32 +37,11 @@ process convertVCFToBed {
     #    otherwise. the sub replacing space is to prevent bedtools from using them as a field separator
     gunzip -c source.vcf.gz | \
     awk -F '\\t' '{ if (!/^#/){ \
-                    printf $1"\\t"$2-1"\\t"$2"\\t"$1; \
-                    for (i=2; i<=NF; i++){ gsub(/%/, "%%", $i); gsub(/ /, "£€", $i); printf "|^"$i }; print "\\t"$4}; \
+                    printf \$1"\\t"\$2-1"\\t"\$2"\\t"\$1; \
+                    for (i=2; i<=NF; i++){ gsub(/%/, "%%", \$i); gsub(/ /, "£€", \$i); printf "|^"\$i }; print "\\t"\$4}; \
                   }' \
                   > variants.bed
-    '''
-}
 
-/*
- * Based on variants BED, generate the BED file for each flank.
- */
-process flankingRegionBed {
-
-    input:
-        path "variants.bed"
-        path "genome.chrom.sizes"
-        val flankingseq
-
-    output:
-        path "flanking_r1.bed", emit: flanking_r1_bed
-        path "flanking_r2.bed", emit: flanking_r2_bed
-
-    script:
-    // The Flanking sequence will start/end one base up/downstream  of the variant.
-    // We need to add only (flankingseq - 1) to that base to have the correct flank length
-    flankingseq = flankingseq - 1
-    """
     # Adjust the end position of the flank to be one base upstream of the variant
     awk 'BEGIN{OFS="\\t"}{\$2=\$2-1; \$3=\$3-1; print \$0}' variants.bed \
         | bedtools slop  -g genome.chrom.sizes -l $flankingseq -r 0  > flanking_r1.bed
@@ -64,57 +52,19 @@ process flankingRegionBed {
 
     # Remove intermediate files
     rm variants.bed
-    """
-}
 
-/*
- * Extract the actual flanking region in fasta format.
- */
-process flankingRegionFasta {
-
-    memory '4 GB'
-
-    input:  
-        path "flanking_r1.bed"
-        path "flanking_r2.bed"
-        path "genome.fa"
-        path "genome.fa.fai"
-    
-    output:
-        path "variants_read1.fa", emit: variants_read1
-        path "variants_read2.fa", emit: variants_read2
-
-    '''
     # Get the fasta sequences for these intervals
     bedtools getfasta -fi genome.fa -bed flanking_r1.bed -fo variants_read1.fa
     bedtools getfasta -fi genome.fa -bed flanking_r2.bed -fo variants_read2.fa
-    '''
-}
 
-/*
- * Extract information about the original variants and put it in the fasta header
- */
-process extractVariantInfoToFastaHeader {
-
-    memory '6GB'
-
-    input:  
-        path "flanking_r1.bed"
-        path "flanking_r2.bed"
-        path "variants_read1.fa"
-        path "variants_read2.fa"
-
-    output:
-        path "interleaved.fa", emit: interleaved_fasta
-
-    // Disable Nextflow string interpolation using single quotes
-    // https://www.nextflow.io/docs/latest/script.html#string-interpolation
-    '''
     # Store variant position in the file to have a unique name
     awk '{print ">" NR }' flanking_r1.bed > position.txt
 
     # Store position of the variant in the file and replace '£€' with the original whitespace from convertVCFToBed
     cut -f 4 flanking_r1.bed | sed 's/£€/ /g' > vcf_fields.txt
+
+    # Remove intermediate files
+    rm flanking_r1.bed flanking_r2.bed
 
     # Paste the names, variant bases, then fasta sequences into a new file
     # A space will be inserted between the position and the vcf fields
@@ -124,12 +74,15 @@ process extractVariantInfoToFastaHeader {
     paste -d '\\n' position.txt <(grep -v '^>' variants_read2.fa) > variant_read2.out.fa
 
     # Remove intermediate files
-    rm vcf_fields.txt
+    rm vcf_fields.txt position.txt variants_read1.fa variants_read2.fa
 
-    paste variant_read1.out.fa variant_read2.out.fa | paste - - | awk -F "\\t" 'BEGIN {OFS="\\n"} {print $1,$3,$2,$4}' > interleaved.fa
+    paste variant_read1.out.fa variant_read2.out.fa | \
+    paste - - | \
+    awk -F "\\t" 'BEGIN {OFS="\\n"} {print \$1,\$3,\$2,\$4}' > interleaved.fa
+    
     # Remove intermediate files
-    rm flanking_r1.bed flanking_r2.bed variants_read1.fa variants_read2.fa
-    '''
+    rm variant_read1.out.fa variant_read2.out.fa
+    """
 }
 
 /*
@@ -293,13 +246,15 @@ process merge_variants {
         path "summary*.yml"
 
     output:
-       path "variants_remapped.vcf", emit: variants_remapped
-       path "variants_unmapped.vcf", emit: variants_unmapped
+       path "variants_remapped.vcf.gz", emit: variants_remapped
+       path "variants_unmapped.vcf.gz", emit: variants_unmapped
        path "output_summary.yml", emit: summary_yml
 
     """
     cat remapped*.vcf > variants_remapped.vcf
+    bgzip variants_remapped.vcf
     cat unmapped*.vcf > variants_unmapped.vcf
+    bgzip variants_unmapped.vcf
     ${baseDir}/variant_remapping_tools/merge_yaml.py --input summary*.yml --output output_summary.yml
     """
 
@@ -319,15 +274,12 @@ workflow process_split_reads_generic {
         chunk_size
 
     main:
-        convertVCFToBed(source_vcf)
-        flankingRegionBed(convertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
-        flankingRegionFasta(
-            flankingRegionBed.out.flanking_r1_bed, flankingRegionBed.out.flanking_r2_bed,
-            old_genome_fa, old_genome_fa_fai
-        )
         extractVariantInfoToFastaHeader(
-            flankingRegionBed.out.flanking_r1_bed, flankingRegionBed.out.flanking_r2_bed,
-            flankingRegionFasta.out.variants_read1, flankingRegionFasta.out.variants_read2
+            source_vcf,
+            old_genome_chrom_sizes,
+            old_genome_fa,
+            old_genome_fa_fai,
+            flank_length
         )
 
         split_fasta(
@@ -444,8 +396,7 @@ workflow process_split_reads_with_bowtie {
 
     main:
         flank_length = 50
-        convertVCFToBed(source_vcf)
-        flankingRegionBed(convertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
+        flankingRegionBed(source_vcf, old_genome_chrom_sizes, flank_length)
         flankingRegionFasta(
             flankingRegionBed.out.flanking_r1_bed, flankingRegionBed.out.flanking_r2_bed,
             old_genome_fa, old_genome_fa_fai


### PR DESCRIPTION
## Description

This pull request was created to deal with large amount of space necessary to run variant remapping pipeline. Therefore, a few modifications were made to remove intermediate files, not using uncompressed files and removal of not necessary tasks.

## Test

1) Used a single chromossome **38** from ROS_Cfam with CanFam3.1 using master and this PR `.nf`

## Conclusion

1) Resuming workflow (using `-resume`) might not work after few steps. So if pipelines breaks or it needs to be stopped, it will probably start from beginning.
2) This will not accelerate workflow running time.